### PR TITLE
Adding Serialize, Deserialize to all types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "antelope-client"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "antelope-client-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "antelope-client"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "antelope-client-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64",
@@ -54,6 +54,7 @@ dependencies = [
  "reqwest",
  "ripemd",
  "serde",
+ "serde-big-array",
  "serde_json",
  "sha2",
  "signature",
@@ -1133,6 +1134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Jesse Schulman <jesse@telos.net>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Jesse Schulman <jesse@telos.net>"]

--- a/crates/antelope/Cargo.toml
+++ b/crates/antelope/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.8.5"
 ripemd = "0.1.3"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
+serde-big-array = "0.5.1"
 sha2 = "0.10.8"
 signature = { version = "2.2.0", features = ["rand_core"] }
 digest = { version = "0.10.7", features = [] }

--- a/crates/antelope/src/chain/action.rs
+++ b/crates/antelope/src/chain/action.rs
@@ -1,9 +1,10 @@
 use crate::chain::checksum::Checksum256;
 use crate::chain::{name::Name, varint::VarUint32};
+use serde::{Deserialize, Serialize};
 
 use crate::serializer::{Decoder, Encoder, Packer};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct PermissionLevel {
     /// The account holding the permission.
     pub actor: Name,
@@ -46,7 +47,7 @@ impl Packer for PermissionLevel {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Action {
     /// The account on which the action is executed.
     pub account: Name,
@@ -60,12 +61,10 @@ pub struct Action {
 
 impl Action {
     /// Creates an action by specifying contract account, action name, authorization and data.
-    pub fn new(
-        account: Name,
-        name: Name,
-        authorization: PermissionLevel,
-        data: &dyn Packer,
-    ) -> Self {
+    pub fn new<T>(account: Name, name: Name, authorization: PermissionLevel, data: T) -> Self
+    where
+        T: Packer,
+    {
         let mut enc = Encoder::new(data.size());
         data.pack(&mut enc);
         Self {
@@ -76,12 +75,15 @@ impl Action {
         }
     }
 
-    pub fn new_ex(
+    pub fn new_ex<T>(
         account: Name,
         name: Name,
         authorizations: Vec<PermissionLevel>,
-        data: &dyn Packer,
-    ) -> Self {
+        data: T,
+    ) -> Self
+    where
+        T: Packer,
+    {
         let mut enc = Encoder::new(data.size());
         data.pack(&mut enc);
         Self {
@@ -142,7 +144,7 @@ impl Packer for Action {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct GetCodeHashResult {
     struct_version: VarUint32,
     code_sequence: u64,

--- a/crates/antelope/src/chain/asset.rs
+++ b/crates/antelope/src/chain/asset.rs
@@ -1,4 +1,5 @@
 use core::ops;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 use crate::chain::name::Name;
@@ -38,7 +39,7 @@ pub fn is_valid_symbol_code(sym: u64) -> bool {
     true
 }
 
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SymbolCode {
     ///
     pub value: u64,
@@ -109,7 +110,7 @@ impl Packer for SymbolCode {
     }
 }
 
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Symbol {
     value: u64,
 }
@@ -178,7 +179,7 @@ impl Packer for Symbol {
     }
 }
 
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Asset {
     amount: i64,
     symbol: Symbol,
@@ -406,7 +407,7 @@ impl Packer for Asset {
     }
 }
 
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ExtendedAsset {
     quantity: Asset,
     contract: Name,

--- a/crates/antelope/src/chain/block_id.rs
+++ b/crates/antelope/src/chain/block_id.rs
@@ -1,8 +1,9 @@
 use crate::chain::{Decoder, Encoder, Packer};
 use antelope_client_macros::StructPacker;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Eq, PartialEq, StructPacker)]
+#[derive(Clone, Eq, PartialEq, StructPacker, Serialize, Deserialize)]
 pub struct BlockId {
     pub bytes: Vec<u8>,
 }

--- a/crates/antelope/src/chain/checksum.rs
+++ b/crates/antelope/src/chain/checksum.rs
@@ -1,10 +1,12 @@
 use crate::chain::{Encoder, Packer};
 use crate::util::{bytes_to_hex, hex_to_bytes, slice_copy};
 use ripemd::{Digest as Ripemd160Digest, Ripemd160};
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
 use sha2::{Sha256, Sha512};
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Copy, Eq, PartialEq, Default)]
+#[derive(Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Checksum160 {
     pub data: [u8; 20],
 }
@@ -62,7 +64,7 @@ impl Packer for Checksum160 {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Default)]
+#[derive(Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Checksum256 {
     pub data: [u8; 32],
 }
@@ -117,8 +119,9 @@ impl Packer for Checksum256 {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Checksum512 {
+    #[serde(with = "BigArray")]
     pub data: [u8; 64],
 }
 

--- a/crates/antelope/src/chain/key_type.rs
+++ b/crates/antelope/src/chain/key_type.rs
@@ -1,7 +1,8 @@
 use crate::chain::{Encoder, Packer};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Copy, Eq, PartialEq, Default)]
+#[derive(Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub enum KeyType {
     #[default]
     K1,

--- a/crates/antelope/src/chain/name.rs
+++ b/crates/antelope/src/chain/name.rs
@@ -1,4 +1,5 @@
 use crate::serializer::{Encoder, Packer};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 const INVALID_NAME_CHAR: u8 = 0xffu8;
@@ -171,7 +172,7 @@ fn str_to_name_checked(s: &str) -> u64 {
 
 /// a wrapper around a 64-bit unsigned integer that represents a name in the Antelope blockchain
 #[repr(C, align(8))]
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Name {
     pub n: u64,
 }

--- a/crates/antelope/src/chain/private_key.rs
+++ b/crates/antelope/src/chain/private_key.rs
@@ -7,9 +7,10 @@ use crate::crypto::generate::generate;
 use crate::crypto::get_public::get_public;
 use crate::crypto::shared_secrets::shared_secret;
 use crate::crypto::sign::sign;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub struct PrivateKey {
     pub key_type: KeyType,
     value: Vec<u8>,

--- a/crates/antelope/src/chain/public_key.rs
+++ b/crates/antelope/src/chain/public_key.rs
@@ -2,9 +2,10 @@ use crate::base58::{decode_public_key, encode_ripemd160_check};
 use crate::chain::{key_type::KeyType, Decoder, Encoder, Packer};
 use crate::util::bytes_to_hex;
 use antelope_client_macros::StructPacker;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+#[derive(Clone, Eq, PartialEq, Default, StructPacker, Serialize, Deserialize)]
 pub struct PublicKey {
     pub key_type: KeyType,
     pub value: Vec<u8>,

--- a/crates/antelope/src/chain/signature.rs
+++ b/crates/antelope/src/chain/signature.rs
@@ -10,9 +10,10 @@ use crate::util::slice_copy;
 use ecdsa::RecoveryId;
 use k256::Secp256k1;
 use p256::NistP256;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Signature {
     pub key_type: KeyType,
     value: Vec<u8>,

--- a/crates/antelope/src/chain/time.rs
+++ b/crates/antelope/src/chain/time.rs
@@ -1,7 +1,8 @@
 use crate::chain::{Encoder, Packer};
 use chrono::{NaiveDateTime, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Default, PartialEq)]
+#[derive(Copy, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TimePoint {
     /// elapsed in microseconds
     pub elapsed: u64,
@@ -42,7 +43,7 @@ impl Packer for TimePoint {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct TimePointSec {
     ///
     pub seconds: u32,

--- a/crates/antelope/src/chain/transaction.rs
+++ b/crates/antelope/src/chain/transaction.rs
@@ -5,16 +5,17 @@ use crate::chain::{
 };
 use crate::util::{bytes_to_hex, zlib_compress};
 use antelope_client_macros::StructPacker;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
-#[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+#[derive(Clone, Eq, PartialEq, Default, StructPacker, Serialize, Deserialize)]
 pub struct TransactionExtension {
     pub ty: u16,
     pub data: Vec<u8>,
 }
 
-#[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+#[derive(Clone, Eq, PartialEq, Default, StructPacker, Serialize, Deserialize)]
 pub struct TransactionHeader {
     pub expiration: TimePointSec,
     pub ref_block_num: u16,
@@ -24,7 +25,7 @@ pub struct TransactionHeader {
     pub delay_sec: VarUint32,
 }
 
-#[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+#[derive(Clone, Eq, PartialEq, Default, StructPacker, Serialize, Deserialize)]
 pub struct Transaction {
     pub header: TransactionHeader,
     pub context_free_actions: Vec<Action>,
@@ -50,7 +51,7 @@ impl Transaction {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+#[derive(Clone, Eq, PartialEq, Default, StructPacker, Serialize, Deserialize)]
 pub struct SignedTransaction {
     pub transaction: Transaction,
     pub signatures: Vec<Signature>,
@@ -72,7 +73,7 @@ impl CompressionType {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Default, StructPacker)]
+#[derive(Clone, Eq, PartialEq, Default, StructPacker, Serialize, Deserialize)]
 pub struct PackedTransaction {
     signatures: Vec<Signature>,
     compression: Option<u8>,

--- a/crates/antelope/src/chain/varint.rs
+++ b/crates/antelope/src/chain/varint.rs
@@ -1,6 +1,7 @@
 use crate::serializer::{Encoder, Packer};
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Eq, PartialEq, Default, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Default, Debug, Serialize, Deserialize)]
 pub struct VarUint32 {
     /// The unsigned integer value.
     pub n: u32,

--- a/crates/antelope/tests/chain.rs
+++ b/crates/antelope/tests/chain.rs
@@ -269,7 +269,7 @@ fn transaction() {
         name!("eosio.token"),
         name!("transfer"),
         vec![],
-        &transfer_data,
+        transfer_data,
     );
 
     let action_packed = Encoder::pack(&action);

--- a/crates/antelope/tests/utils/mock_provider.rs
+++ b/crates/antelope/tests/utils/mock_provider.rs
@@ -74,7 +74,7 @@ pub fn make_mock_transaction(info: &GetInfoResponse, asset_to_transfer: Asset) -
         name!("eosio.token"),
         name!("transfer"),
         vec![PermissionLevel::new(name!("corecorecore"), name!("active"))],
-        &transfer_data,
+        transfer_data,
     );
 
     Transaction {


### PR DESCRIPTION
Adds serde traits on all the antelope types.  Does not implement on user defined structs via the StructPacker macro as that leads to lifetimes being required everywhere, users can add that themselves if needed and then also define lifetimes.
