### PR TITLE
[CI] Added `--all-targets` as parameter of `cargo clippy`

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -63,4 +63,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets -- -D warnings

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,4 +1,6 @@
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ "development" ]
 
 name: Continuous integration
 

--- a/crates/antelope/src/api/v1/structs.rs
+++ b/crates/antelope/src/api/v1/structs.rs
@@ -1085,7 +1085,7 @@ mod tests {
         }
         "#;
 
-        let res = serde_json::from_str::<AccountObject>(&simple_account_json).unwrap();
+        let res = serde_json::from_str::<AccountObject>(simple_account_json).unwrap();
         println!("{:#?}", res);
     }
 
@@ -1192,7 +1192,7 @@ mod tests {
         }
         "#;
 
-        let res = serde_json::from_str::<AccountObject>(&detailed_account_json).unwrap();
+        let res = serde_json::from_str::<AccountObject>(detailed_account_json).unwrap();
         println!("{:#?}", res);
     }
 
@@ -1299,7 +1299,7 @@ mod tests {
         }
         "#;
 
-        let res = serde_json::from_str::<AccountObject>(&detailed_account_json).unwrap();
+        let res = serde_json::from_str::<AccountObject>(detailed_account_json).unwrap();
         println!("{:#?}", res);
     }
 }

--- a/crates/antelope/tests/client.rs
+++ b/crates/antelope/tests/client.rs
@@ -1,7 +1,4 @@
-use antelope::api::client::DefaultProvider;
-use antelope::api::v1::structs::{
-    ErrorResponse, IndexPosition, SendTransactionResponse, TableIndexType,
-};
+use antelope::api::v1::structs::{ErrorResponse, SendTransactionResponse};
 use antelope::{
     api::{
         client::APIClient,
@@ -122,15 +119,8 @@ async fn chain_send_transaction() {
     let failure_response = failed_result.err().unwrap();
     println!("{:?}", failure_response);
     match failure_response {
-        ClientError::SERVER(err) => {
-            assert_eq!(err.error.code, Some(3050003));
-        }
-        _ => {
-            assert!(
-                false,
-                "Failure response should be of type ClientError::SERVER"
-            )
-        }
+        ClientError::SERVER(err) => assert_eq!(err.error.code, Some(3050003)),
+        _ => panic!("Failure response should be of type ClientError::SERVER"),
     }
 }
 
@@ -270,7 +260,7 @@ fn test_send_transaction_response() {
       }
     }"#;
 
-    let parsed = serde_json::from_str::<SendTransactionResponse>(&response_json);
+    let parsed = serde_json::from_str::<SendTransactionResponse>(response_json);
     assert!(parsed.is_ok());
     let parsed = parsed.unwrap();
     let traces = parsed.processed.action_traces;

--- a/crates/antelope/tests/utils/mock_provider.rs
+++ b/crates/antelope/tests/utils/mock_provider.rs
@@ -33,8 +33,9 @@ impl MockProvider {
         body: Option<String>,
     ) -> Result<String, String> {
         let mut to_hash = method.to_string() + &path;
-        if body.is_some() {
-            to_hash += body.unwrap().as_str();
+
+        if let Some(body) = body {
+            to_hash += body.as_str();
         }
 
         let filename = Checksum160::hash(to_hash.into_bytes()).to_string();


### PR DESCRIPTION
Using `--all-targets` allows the detection of additional warnings that were previously hidden (e.g. in testing code).

In addition, the GitHub Actions configuration is switched to being triggered only when pushing to a PR targeting the `development` branch.