### PR TITLE
Fix for GetTableRows query with sha256 index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Jesse Schulman <jesse@telos.net>"]

--- a/crates/antelope/src/api/v1/structs.rs
+++ b/crates/antelope/src/api/v1/structs.rs
@@ -485,7 +485,7 @@ impl TableIndexType {
             TableIndexType::UINT64(value) => json!(value.to_string()),
             TableIndexType::UINT128(value) => json!(value.to_string()),
             TableIndexType::FLOAT64(value) => json!(value.to_string()),
-            TableIndexType::CHECKSUM256(value) => json!(value.to_index()),
+            TableIndexType::CHECKSUM256(value) => json!(value.as_string()),
             TableIndexType::CHECKSUM160(value) => json!(value.as_string()),
         }
     }


### PR DESCRIPTION
Problem found during writing a `get_account_row_by_addr` helper function in reth, the `.to_index()` function is not appropriate looking at the final json.