### PR TITLE
Include more details in the error message returned by some APIs

### DIFF
--- a/crates/antelope/src/api/v1/chain.rs
+++ b/crates/antelope/src/api/v1/chain.rs
@@ -297,7 +297,12 @@ impl<T: Provider> ChainAPI<T> {
 
         let response = match result.await {
             Ok(response) => response,
-            Err(_) => return Err(ClientError::NETWORK("Failed to get table rows".into())),
+            Err(error) => {
+                return Err(ClientError::NETWORK(format!(
+                    "Failed to get table rows, reason: {}",
+                    error
+                )))
+            }
         };
         let json: Value = serde_json::from_str(response.as_str()).unwrap();
         let response_obj = JSONObject::new(json);

--- a/crates/antelope/src/api/v1/chain.rs
+++ b/crates/antelope/src/api/v1/chain.rs
@@ -151,7 +151,10 @@ impl<T: Provider> ChainAPI<T> {
                 let message = format!("Failed to parse JSON: {}", e);
                 ClientError::encoding(message)
             }),
-            Err(_) => Err(ClientError::encoding("Request failed".into())),
+            Err(error) => Err(ClientError::encoding(format!(
+                "Request failed, reason: {}",
+                error
+            ))),
         }
     }
 


### PR DESCRIPTION
This PR includes some small changes to increase the **verbosity of error messages** returned by some APIs, in particular:

- `get_table_rows`
- `get_info`

This is useful for applications relying on `antelope-rs` to **debug** issues more easily.
